### PR TITLE
add runbook fileformat for handling input

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,9 +1,13 @@
 package main
 
 import (
-	"github.com/nicktitle/redcanary/pkg/agent"
+	"fmt"
+
+	"github.com/nicktitle/rc/pkg/agent"
+	"github.com/nicktitle/rc/pkg/fileformat"
 )
 
 func main() {
+	fmt.Println(fileformat.ExportExample())
 	agent.Start()
 }

--- a/examples/make-mod-del.yml
+++ b/examples/make-mod-del.yml
@@ -1,0 +1,8 @@
+name: make-mod-del
+steps:
+- kind: FileCreate
+  path: ./foo.txt
+- kind: FileModify
+  path: ./foo.txt
+- kind: FileDelete
+  path: ./foo.txt

--- a/pkg/fileformat/runbook.go
+++ b/pkg/fileformat/runbook.go
@@ -1,0 +1,83 @@
+package fileformat
+
+import (
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v2"
+)
+
+type Runbook struct {
+	Name  string
+	Steps []Step
+}
+
+type Step struct {
+	Kind         StepKind
+	Path         string
+	ConnSettings *ConnectionSettings `yaml:"conn-settings,omitempty"`
+}
+
+type ConnectionSettings struct {
+	Destination ConnectionAddress
+	Source      ConnectionAddress
+
+	PayloadSize int
+	Insecure    bool
+}
+
+type ConnectionAddress struct {
+	Host string
+	Port int
+}
+
+type StepKind string
+
+const (
+	FileCreate   StepKind = "FileCreate"
+	FileDelete   StepKind = "FileDelete"
+	FileModify   StepKind = "FileModify"
+	SpawnProcess StepKind = "SpawnProcess"
+	ExfilData    StepKind = "ExfilData"
+)
+
+func ExportExample() string {
+	rb := Runbook{
+		Name: "make-mod-del",
+		Steps: []Step{
+			Step{
+				Kind: FileCreate,
+				Path: "~/tmp/foo.txt",
+			},
+			Step{
+				Kind: FileModify,
+				Path: "~/tmp/foo.txt",
+			},
+			Step{
+				Kind: FileDelete,
+				Path: "~/tmp/foo.txt",
+			},
+		},
+	}
+
+	bytes, err := yaml.Marshal(rb)
+	if err != nil {
+		panic(err)
+	}
+	return string(bytes)
+}
+
+func Validate(path string) (Runbook, error) {
+	var rb Runbook
+
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return rb, errors.Wrap(err, "unable to read file")
+	}
+
+	if err := yaml.Unmarshal(bytes, &rb); err != nil {
+		return rb, errors.New("unable to parse runbook from file")
+	}
+
+	return rb, nil
+}


### PR DESCRIPTION
- what?
  - scratches out the 'runbook' format for describing the tasks the agent needs to complete
  - adds a validate method to ensure that the runbook is valid
  - adds a temporary method to render out some compliant yaml, since i am a human and always somehow mess up my whitespace when writing yaml

- why?
  - by defining this format upfront, and by forcing an unmarshall in order to get back an object I can use to work, I am making the tools for the rest of my binary to use, while putting a sanity check at the front door (can't get a Runbook to work with without validating a path containing one)